### PR TITLE
CSV出力設定を修正

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -8,7 +8,10 @@ class BooksController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.csv { send_data @books.generate_csv, filename: "books-#{Time.zone.now.strftime('%Y%m%d%S')}.csv"}
+      format.csv do
+        @books = @q.result(distinct: true).recent
+        send_data @books.generate_csv, filename: "books-#{Time.zone.now.strftime('%Y%m%d%S')}.csv"
+      end
     end
   end
 


### PR DESCRIPTION
[ 修正理由 ]
・CSVファイル作成時にページネーション の影響を受けて10件しか出力されない不具合が出ていた為

[ 修正内容 ]
・CSV出力のブロック内でインスタンス変数：@booksを再定義
 （ページネーション なしバージョン）
・これにより、CSV出力時はページネーション の影響を受けず全件対象データが出力されるように設定可能となる

![image](https://user-images.githubusercontent.com/49441355/71557698-f3113280-2a8c-11ea-8acd-0d6296cd41a7.png)


![image](https://user-images.githubusercontent.com/49441355/71557692-cfe68300-2a8c-11ea-86e5-4f323ab43e6e.png)
