### PR TITLE
書籍登録機能　バリデーション＋エラーメッセージ表示

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ WORKDIR $APP_ROOT
 ADD ./Gemfile $APP_ROOT/Gemfile
 ADD ./Gemfile.lock $APP_ROOT/Gemfile.lock
 
-RUN gem install bundler -v 2.0.1
+RUN gem install bundler 
 RUN bundle install
 ADD . $APP_ROOT

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'bcrypt', '~> 3.1.7'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platform: :mri
 end
 
 group :development do
@@ -60,3 +59,6 @@ gem 'kaminari'
 gem 'ransack'
 gem 'font-awesome-sass', '~> 5.4.1'
 gem 'dotenv-rails'
+gem 'pry-rails'
+gem 'pry-byebug'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ GEM
       sassc-rails (>= 2.0.0)
     builder (3.2.4)
     byebug (11.0.1)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -113,6 +114,14 @@ GEM
     polyamorous (2.3.0)
       activerecord (>= 5.0)
     popper_js (1.14.5)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.12.2)
     rack (2.0.8)
     rack-test (0.6.3)
@@ -217,7 +226,6 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootstrap
-  byebug
   coffee-rails (~> 4.2)
   dotenv-rails
   enum_help
@@ -228,6 +236,8 @@ DEPENDENCIES
   kaminari
   listen (~> 3.0.5)
   mysql2 (= 0.5.2)
+  pry-byebug
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   ransack

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -110,6 +110,12 @@ nav {
   margin-left: 20px;
 }
 
+/* Book validation */
+.errors {
+  color: tomato;
+  margin-top: 5px;
+}
+
 
 
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,6 +1,6 @@
 class BooksController < ApplicationController
   before_action :set_book, only: [:show,:edit,:update,:destroy]
-  before_action :set_genre, only: [:index, :new, :edit]
+  before_action :set_genre, only: [:index, :new, :edit, :create,:update]
   before_action :login_required 
 
   def index
@@ -32,7 +32,7 @@ class BooksController < ApplicationController
     if @book.save 
       redirect_to books_url, notice: "「#{@book.title}」を登録しました。"
     else
-      render :new
+      render action: :new
     end
   end
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -5,6 +5,7 @@ class Book < ApplicationRecord
   has_many :thoughts, dependent: :destroy
   belongs_to :genre, optional: true
   scope :recent, -> { order(created_at: :desc)}
+  validates :title, presence: true
   
   def self.generate_csv
     column_name = ["書名", "作者", "ジャンル", "状態"]

--- a/app/views/books/_form.html.slim
+++ b/app/views/books/_form.html.slim
@@ -1,7 +1,10 @@
 = form_for book do |f|
   .form-group
-    = f.label :title
+    = f.label '書名（必須）'
     = f.text_field :title, class: 'form-control', id: 'book_name', autocomplete: 'off'
+    - if book.errors.any?
+      .errors
+        = book.errors.full_messages_for(:title)[0]
   .form-group
     = f.label :author
     = f.text_field :author, class: 'form-control', id: 'author', autocomplete: 'off'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
 
   web:
     build: .
+    tty: true
+    stdin_open: true
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/app_name


### PR DESCRIPTION
# What 
書籍登録機能にバリデーションとエラーメッセージ表示を追加する

[補足] 
「作者名、ジャンルは空欄にしておきたい」等のニーズに柔軟に対応できるように、
書名のみバリデーションを設定した

![image](https://user-images.githubusercontent.com/49441355/72387581-2fb87b80-3767-11ea-9b5a-423d4fadd9dc.png)

# Why 
データ登録の柔軟性は担保しつつも、
「書名なし」の意図しないデータについてはエラー表示できるようにする為